### PR TITLE
Refactor SignUpForm component to remove unused props and imports

### DIFF
--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -6,9 +6,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { AlertCircle, CheckCircle2, Mail, Lock, UserPlus, Eye, EyeOff } from 'lucide-react'
-import { useRouter } from 'next/navigation'
 
-export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
+export function SignUpForm() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -17,7 +16,6 @@ export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutR
   const [success, setSuccess] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
-  const router = useRouter()
 
   const supabase = createClient()
 


### PR DESCRIPTION
- Simplified the SignUpForm component by removing the unused className prop and the useRouter import.
- Streamlined the component structure for improved readability and maintainability.